### PR TITLE
Leaflet 1.0.2 compatibility

### DIFF
--- a/src/leaflet.hotline.js
+++ b/src/leaflet.hotline.js
@@ -308,7 +308,7 @@
 
 			this._hotline
 				.data(parts)
-				.draw(this._clear);
+				.draw(false);
 		},
 
 		_updateOptions: function (layer) {


### PR DESCRIPTION
Leaflet v1.0.2 no longuer use `_clear` as indicator in canvas object (replaced by the clear function)
See https://github.com/Leaflet/Leaflet/commit/4c484462dc4d646cb43adc0585401d28d878330d#diff-5b3512e2ba3d374197128a67b330a0efR187

This patch is a partial fix and probably leads to performance reduction. Require some tests
Fix #11 