### PR TITLE
Fix division by zero on equal values in dataset

### DIFF
--- a/src/leaflet.hotline.js
+++ b/src/leaflet.hotline.js
@@ -195,7 +195,7 @@
 		 * @returns {Array.<number>} The RGB values as an array [r, g, b]
 		 */
 		getRGBForValue: function (value) {
-			var valueRelative = Math.min(Math.max((value - this._min) / (this._max - this._min), 0), 0.999);
+			var valueRelative = Math.min(Math.max((value - this._min) / ((this._max - this._min) || 1), 0), 0.999);
 			var paletteIndex = Math.floor(valueRelative * 256) * 4;
 
 			return [


### PR DESCRIPTION
If all z-values in dataset are equal (min = max), there is division by zero issue in getting RGB method